### PR TITLE
Use https for URLs

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -16,7 +16,7 @@ const multipartMiddleware = multipart();
 const cloudinaryRateLimiter = new limiter.RateLimiter(2000, 'hour');
 const router = express.Router();
 
-const defaultCover = 'http://res.cloudinary.com/hpiynhbhq/image/upload/v1501527249/transparent_cliw8u.png';
+const defaultCover = 'https://res.cloudinary.com/hpiynhbhq/image/upload/v1501527249/transparent_cliw8u.png';
 
 const showImage = (url, res) => {
   debug('showImage', url);

--- a/routes/index.js
+++ b/routes/index.js
@@ -46,6 +46,7 @@ const renderExternalImage = (url, res, defaultImage, options) => {
   const fetchOptions = Object.assign({}, options, {
     type: 'fetch',
     sign_url: true,
+    secure: true,
     defaultImage,
   });
   const newUrl = cloudinary.url(url, fetchOptions);


### PR DESCRIPTION
Now cloudinary returns HTTPS links instead of HTTP ones.